### PR TITLE
Support templated classes (conditionally)

### DIFF
--- a/libs/core/type_support/include/hpx/type_support/is_trivially_relocatable.hpp
+++ b/libs/core/type_support/include/hpx/type_support/is_trivially_relocatable.hpp
@@ -19,33 +19,26 @@
 
 #define HPX_DECLARE_TRIVIALLY_RELOCATABLE_TEMPLATE(T)                          \
     namespace hpx {                                                            \
-        template <typename K>                                                  \
-        struct is_trivially_relocatable<T<K>> : std::true_type                 \
+        template <typename... K>                                               \
+        struct is_trivially_relocatable<T<K...>> : std::true_type              \
         {                                                                      \
         };                                                                     \
     }
 
 #define HPX_DECLARE_TRIVIALLY_RELOCATABLE_TEMPLATE_IF(T, Condition)            \
     namespace hpx {                                                            \
-        template <typename K>                                                  \
-        struct is_trivially_relocatable<T<K>>                                  \
-          : std::conditional_t<Condition<K>::value, std::true_type,            \
-                std::false_type>                                               \
+        template <typename... K>                                               \
+        struct is_trivially_relocatable<T<K...>> : Condition<K...>             \
         {                                                                      \
         };                                                                     \
     }
 
 namespace hpx {
 
-    template <typename T, typename = void>
-    struct is_trivially_relocatable : std::false_type
-    {
-    };
-
-    // All trivially copyable types are trivially relocatable
     template <typename T>
-    struct is_trivially_relocatable<T,
-        std::enable_if_t<std::is_trivially_copyable_v<T>>> : std::true_type
+    // All trivially copyable types are trivially relocatable
+    // Other types should default to false.
+    struct is_trivially_relocatable : std::is_trivially_copyable<T>
     {
     };
 

--- a/libs/core/type_support/include/hpx/type_support/is_trivially_relocatable.hpp
+++ b/libs/core/type_support/include/hpx/type_support/is_trivially_relocatable.hpp
@@ -17,6 +17,24 @@
         };                                                                     \
     }
 
+#define HPX_DECLARE_TRIVIALLY_RELOCATABLE_TEMPLATE(T)                          \
+    namespace hpx {                                                            \
+        template <typename K>                                                  \
+        struct is_trivially_relocatable<T<K>> : std::true_type                 \
+        {                                                                      \
+        };                                                                     \
+    }
+
+#define HPX_DECLARE_TRIVIALLY_RELOCATABLE_TEMPLATE_IF(T, Condition)            \
+    namespace hpx {                                                            \
+        template <typename K>                                                  \
+        struct is_trivially_relocatable<T<K>>                                  \
+          : std::conditional_t<Condition<K>::value, std::true_type,            \
+                std::false_type>                                               \
+        {                                                                      \
+        };                                                                     \
+    }
+
 namespace hpx {
 
     template <typename T, typename = void>

--- a/libs/core/type_support/tests/unit/is_trivially_relocatable.cpp
+++ b/libs/core/type_support/tests/unit/is_trivially_relocatable.cpp
@@ -160,7 +160,8 @@ struct non_trivially_copyable_container
 
     non_trivially_copyable_container();
     non_trivially_copyable_container(non_trivially_copyable_container const&);
-    non_trivially_copyable_container& operator=(non_trivially_copyable_container const&);
+    non_trivially_copyable_container& operator=(
+        non_trivially_copyable_container const&);
     ~non_trivially_copyable_container();
 };
 HPX_DECLARE_TRIVIALLY_RELOCATABLE_TEMPLATE_IF(

--- a/libs/core/type_support/tests/unit/is_trivially_relocatable.cpp
+++ b/libs/core/type_support/tests/unit/is_trivially_relocatable.cpp
@@ -5,6 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/type_support/is_trivially_relocatable.hpp>
+#include <type_traits>
 
 #include <cassert>
 
@@ -55,6 +56,9 @@ static_assert(
 static_assert(
     hpx::is_trivially_relocatable_v<non_assignable_but_trivially_copyable>);
 
+// Non trivially copyable types should not be considered trivially
+// relocatable by default
+
 // Has non trivial copy constructor
 struct not_trivially_copyable_1
 {
@@ -84,11 +88,12 @@ struct not_trivially_copyable_3
     ~not_trivially_copyable_3();
 };
 
-// Non trivially copyable types are not trivially relocatable
-// Unless they are explicitly declared as such
 static_assert(!hpx::is_trivially_relocatable_v<not_trivially_copyable_1>);
 static_assert(!hpx::is_trivially_relocatable_v<not_trivially_copyable_2>);
 static_assert(!hpx::is_trivially_relocatable_v<not_trivially_copyable_2>);
+
+// The HPX_DECLARE_TRIVIALLY_RELOCATABLE macro declares types as trivially
+// relocatable
 
 // Not trivially copyable
 struct explicitly_trivially_relocatable_1
@@ -136,27 +141,58 @@ struct polymorphic
 };
 static_assert(!hpx::is_trivially_relocatable_v<polymorphic>);
 
-#include <vector>
-
-HPX_DECLARE_TRIVIALLY_RELOCATABLE_TEMPLATE(std::vector)
-static_assert(hpx::is_trivially_relocatable_v<std::vector<int>>);
-
-struct trivially_relocatable
+// Test that it is not breaking to declare an already known
+// trivially copyable type to be trivially relocatable
+struct trivially_copyable_explicitly_trivially_relocatable
 {
+    int i;
+    trivially_copyable_explicitly_trivially_relocatable(
+        trivially_copyable_explicitly_trivially_relocatable const&) = default;
+    trivially_copyable_explicitly_trivially_relocatable& operator=(
+        trivially_copyable_explicitly_trivially_relocatable const&) = default;
+    ~trivially_copyable_explicitly_trivially_relocatable() = default;
+};
+HPX_DECLARE_TRIVIALLY_RELOCATABLE(
+    trivially_copyable_explicitly_trivially_relocatable);
+
+static_assert(std::is_trivially_copyable_v<
+    trivially_copyable_explicitly_trivially_relocatable>);
+static_assert(hpx::is_trivially_relocatable_v<
+    trivially_copyable_explicitly_trivially_relocatable>);
+
+// Testing the HPX_DECLARE_TRIVIALLY_RELOCATABLE_TEMPLATE macro
+template <typename T, typename K>
+struct non_trivially_copyable
+{
+    non_trivially_copyable(non_trivially_copyable const&);
+    non_trivially_copyable operator=(non_trivially_copyable const&);
+    ~non_trivially_copyable();
 };
 
-struct non_trivially_relocatable
+static_assert(!std::is_trivially_copyable_v<non_trivially_copyable<int, int>>);
+
+HPX_DECLARE_TRIVIALLY_RELOCATABLE_TEMPLATE(non_trivially_copyable);
+static_assert(
+    hpx::is_trivially_relocatable_v<non_trivially_copyable<int, int>>);
+
+// Testing the HPX_DECLARE_TRIVIALLY_RELOCATABLE_TEMPLATE_IF macro
+struct trivially_relocatable_struct
 {
-    non_trivially_relocatable(non_trivially_relocatable const&);
 };
+static_assert(hpx::is_trivially_relocatable_v<trivially_relocatable_struct>);
 
-static_assert(hpx::is_trivially_relocatable_v<trivially_relocatable>);
-static_assert(!hpx::is_trivially_relocatable_v<non_trivially_relocatable>);
+struct non_trivially_relocatable_struct
+{
+    non_trivially_relocatable_struct(non_trivially_relocatable_struct const&);
+};
+static_assert(
+    !hpx::is_trivially_relocatable_v<non_trivially_relocatable_struct>);
 
-template <typename T>
+template <typename T, typename K>
 struct non_trivially_copyable_container
 {
     T t;
+    K k;
 
     non_trivially_copyable_container();
     non_trivially_copyable_container(non_trivially_copyable_container const&);
@@ -164,13 +200,30 @@ struct non_trivially_copyable_container
         non_trivially_copyable_container const&);
     ~non_trivially_copyable_container();
 };
-HPX_DECLARE_TRIVIALLY_RELOCATABLE_TEMPLATE_IF(
-    non_trivially_copyable_container, hpx::is_trivially_relocatable)
+// If T is triviialy relocatable then non_trivially_copyable_container is
+// trivially relocatable too.
 
-static_assert(hpx::is_trivially_relocatable_v<
-    non_trivially_copyable_container<trivially_relocatable>>);
-static_assert(!hpx::is_trivially_relocatable_v<
-              non_trivially_copyable_container<non_trivially_relocatable>>);
+template <typename T, typename K>
+struct my_metafunction
+  : std::bool_constant<hpx::is_trivially_relocatable_v<T> &&
+        hpx::is_trivially_relocatable_v<K>>
+{
+};
+
+HPX_DECLARE_TRIVIALLY_RELOCATABLE_TEMPLATE_IF(
+    non_trivially_copyable_container, my_metafunction)
+
+static_assert(hpx::is_trivially_relocatable_v<non_trivially_copyable_container<
+        trivially_relocatable_struct, trivially_relocatable_struct>>);
+static_assert(
+    !hpx::is_trivially_relocatable_v<non_trivially_copyable_container<
+        trivially_relocatable_struct, non_trivially_relocatable_struct>>);
+static_assert(
+    !hpx::is_trivially_relocatable_v<non_trivially_copyable_container<
+        non_trivially_relocatable_struct, trivially_relocatable_struct>>);
+static_assert(
+    !hpx::is_trivially_relocatable_v<non_trivially_copyable_container<
+        non_trivially_relocatable_struct, non_trivially_relocatable_struct>>);
 
 // Primitive data types are trivially relocatable
 static_assert(hpx::is_trivially_relocatable_v<int>,

--- a/libs/core/type_support/tests/unit/is_trivially_relocatable.cpp
+++ b/libs/core/type_support/tests/unit/is_trivially_relocatable.cpp
@@ -136,6 +136,41 @@ struct polymorphic
 };
 static_assert(!hpx::is_trivially_relocatable_v<polymorphic>);
 
+#include <vector>
+
+HPX_DECLARE_TRIVIALLY_RELOCATABLE_TEMPLATE(std::vector)
+static_assert(hpx::is_trivially_relocatable_v<std::vector<int>>);
+
+struct trivially_relocatable
+{
+};
+
+struct non_trivially_relocatable
+{
+    non_trivially_relocatable(non_trivially_relocatable const&);
+};
+
+static_assert(hpx::is_trivially_relocatable_v<trivially_relocatable>);
+static_assert(!hpx::is_trivially_relocatable_v<non_trivially_relocatable>);
+
+template <typename T>
+struct non_trivially_copyable_container
+{
+    T t;
+
+    non_trivially_copyable_container();
+    non_trivially_copyable_container(non_trivially_copyable_container const&);
+    non_trivially_copyable_container& operator=(non_trivially_copyable_container const&);
+    ~non_trivially_copyable_container();
+};
+HPX_DECLARE_TRIVIALLY_RELOCATABLE_TEMPLATE_IF(
+    non_trivially_copyable_container, hpx::is_trivially_relocatable)
+
+static_assert(hpx::is_trivially_relocatable_v<
+    non_trivially_copyable_container<trivially_relocatable>>);
+static_assert(!hpx::is_trivially_relocatable_v<
+              non_trivially_copyable_container<non_trivially_relocatable>>);
+
 // Primitive data types are trivially relocatable
 static_assert(hpx::is_trivially_relocatable_v<int>,
     "int should be Trivially Relocatable");


### PR DESCRIPTION
This adds two new macros: HPX_DECLARE_TRIVIALLY_RELOCATABLE_TEMPLATE and HPX_DECLARE_TRIVIALLY_RELOCATABLE_TEMPLATE_IF

To mimic P1144's: `[[trivially_relocatable]]` and `[[trivially_relocatable(bool)]]`