### PR TITLE
Small vector relocation

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/algorithms/uninitialized_relocate.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/uninitialized_relocate.hpp
@@ -63,7 +63,7 @@ namespace hpx {
     template <typename InIter1, typename InIter2, typename FwdIter>
     FwdIter uninitialized_relocate(InIter1 first, InIter2 last, FwdIter dest);
 
-    /// Relocates the elements in the range defined by [first, first + count), to an
+    /// Relocates the elements in the range defined by [first, last), to an
     /// uninitialized memory area beginning at \a dest. If an exception is
     /// thrown during the move-construction of an element, all elements left
     /// in the input range, as well as all objects already constructed in the
@@ -134,6 +134,125 @@ namespace hpx {
     hpx::parallel::util::detail::algorithm_result_t<ExPolicy, FwdIter>
     uninitialized_relocate(
         ExPolicy&& policy, InIter1 first, InIter2 last, FwdIter dest);
+
+    /// Relocates the elements in the range, defined by [first, last), to an
+    /// uninitialized memory area ending at \a dest_last. The objects are
+    /// processed in reverse order. If an exception is thrown during the
+    /// the move-construction of an element, all elements left in the
+    /// input range, as well as all objects already constructed in the
+    /// destination range are destroyed. After this algorithm completes, the
+    /// source range should be freed or reused without destroying the objects.
+    ///
+    /// \note   Complexity: time: O(n), space: O(1)
+    ///         1)  For "trivially relocatable" underlying types (T) and
+    ///             a contiguous iterator range [first, last):
+    ///             std::distance(first, last)*sizeof(T) bytes are copied.
+    ///         2)  For "trivially relocatable" underlying types (T) and
+    ///             a non-contiguous iterator range [first, last):
+    ///             std::distance(first, last) memory copies of sizeof(T)
+    ///             bytes each are performed.
+    ///         3)  For "non-trivially relocatable" underlying types (T):
+    ///             std::distance(first, last) move assignments and
+    ///             destructions are performed.
+    ///
+    /// \note   Declare a type as "trivially relocatable" using the
+    ///         `HPX_DECLARE_TRIVIALLY_RELOCATABLE` macros found in
+    ///         <hpx/type_support/is_trivially_relocatable.hpp>.
+    ///
+    /// \tparam BiIter1     The type of the source range (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     Bidirectional iterator.
+    /// \tparam BiIter2     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     Bidirectional iterator.
+    ///
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest_last    Refers to the beginning of the destination range.
+    ///  
+    /// The assignments in the parallel \a uninitialized_relocate algorithm invoked
+    /// without an execution policy object will execute in sequential order in
+    /// the calling thread.
+    ///
+    /// \returns  The \a uninitialized_relocate_backward algorithm returns \a BiIter2.
+    ///           The \a uninitialized_relocate_backward algorithm returns the 
+    ///           bidirectional iterator to the first element in the destination range.
+    ///
+    template <typename BiIter1, typename BiIter2>
+    BiIter2 uninitialized_relocate_backward(BiIter1 first, BiIter1 last,
+            BiIter2 dest_last)
+
+    /// Relocates the elements in the range, defined by [first, last), to an
+    /// uninitialized memory area ending at \a dest_last. The order of the 
+    /// relocation of the objects depends on the execution policy. If an 
+    /// exception is thrown during the  the move-construction of an element, 
+    /// all elements left in the input range, as well as all objects already 
+    /// constructed in the destination range are destroyed. After this algorithm 
+    /// completes, the source range should be freed or reused without destroying 
+    /// the objects.
+    ///
+    /// \note   Using the \a uninitialized_relocate_backward algorithm with the
+    ///         with a non-sequenced execution policy, will not guarantee the
+    ///         order of the relocation of the objects.
+    ///
+    /// \note   Complexity: time: O(n), space: O(1)
+    ///         1)  For "trivially relocatable" underlying types (T) and
+    ///             a contiguous iterator range [first, last):
+    ///             std::distance(first, last)*sizeof(T) bytes are copied.
+    ///         2)  For "trivially relocatable" underlying types (T) and
+    ///             a non-contiguous iterator range [first, last):
+    ///             std::distance(first, last) memory copies of sizeof(T)
+    ///             bytes each are performed.
+    ///         3)  For "non-trivially relocatable" underlying types (T):
+    ///             std::distance(first, last) move assignments and
+    ///             destructions are performed.
+    ///
+    /// \note   Declare a type as "trivially relocatable" using the
+    ///         `HPX_DECLARE_TRIVIALLY_RELOCATABLE` macros found in
+    ///         <hpx/type_support/is_trivially_relocatable.hpp>.
+    ///
+    /// \tparam ExPolicy    The type of the execution policy to use (deduced).
+    ///                     It describes the manner in which the execution
+    ///                     of the algorithm may be parallelized and the manner
+    ///                     in which it executes the assignments.
+    /// \tparam BiIter1     The type of the source range (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     Bidirectional iterator.
+    /// \tparam BiIter2     The type of the iterator representing the
+    ///                     destination range (deduced).
+    ///                     This iterator type must meet the requirements of a
+    ///                     Bidirectional iterator.
+    ///
+    /// \param policy       The execution policy to use for the scheduling of
+    ///                     the iterations.
+    /// \param first        Refers to the beginning of the sequence of elements
+    ///                     the algorithm will be applied to.
+    /// \param last         Refers to the end of the sequence of elements the
+    ///                     algorithm will be applied to.
+    /// \param dest_last    Refers to the end of the destination range.
+    ///
+    /// The assignments in the parallel \a uninitialized_relocate_backward algorithm invoked
+    /// with an execution policy object of type \a parallel_policy or
+    /// \a parallel_task_policy are permitted to execute in an
+    /// unordered fashion in unspecified threads, and indeterminately sequenced
+    /// within each thread.
+    ///
+    /// \returns  The \a uninitialized_relocate_backward algorithm returns a
+    ///           \a hpx::future<FwdIter>, if the execution policy is of type
+    ///           \a sequenced_task_policy or
+    ///           \a parallel_task_policy and
+    ///           returns \a BiIter2 otherwise.
+    ///           The \a uninitialized_relocate_backward algorithm returns the 
+    ///           bidirectional iterator to the first element in the destination 
+    ///           range.
+    ///
+    template <typename ExPolicy, typename BiIter1, typename BiIter2>
+    hpx::parallel::util::detail::algorithm_result<ExPolicy, BiIter2>
+    uninitialized_relocate_backward(
+        ExPolicy&& policy, BiIter1 first, BiIter1 last, BiIter2 dest_last)
 
     /// Relocates the elements in the range, defined by [first, last), to an
     /// uninitialized memory area beginning at \a dest. If an exception is

--- a/libs/core/datastructures/include/hpx/datastructures/detail/small_vector.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/detail/small_vector.hpp
@@ -34,6 +34,8 @@
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/type_support/construct_at.hpp>
+#include <hpx/type_support/is_trivially_relocatable.hpp>
+#include <hpx/type_support/uninitialized_relocation_primitives.hpp>
 
 #include <algorithm>
 #include <array>
@@ -294,20 +296,6 @@ namespace hpx::detail {
                 reinterpret_cast<T*>(m_data.data() + std::alignment_of_v<T>));
         }
 
-        static void uninitialized_move_and_destroy(
-            T* source_ptr, T* target_ptr, std::size_t size) noexcept
-        {
-            if constexpr (std::is_trivially_copyable_v<T>)
-            {
-                std::memcpy(target_ptr, source_ptr, size * sizeof(T));
-            }
-            else
-            {
-                std::uninitialized_move_n(source_ptr, size, target_ptr);
-                std::destroy_n(source_ptr, size);
-            }
-        }
-
         void realloc(std::size_t new_capacity)
         {
             if (new_capacity <= N)
@@ -319,8 +307,9 @@ namespace hpx::detail {
                 {
                     // indirect -> direct
                     auto* storage = indirect();
-                    uninitialized_move_and_destroy(
-                        storage->data(), direct_data(), storage->size());
+                    ::hpx::experimental::util::
+                        uninitialized_relocate_n_primitive(
+                            storage->data(), storage->size(), direct_data());
                     set_direct_and_size(storage->size());
                     detail::storage<T>::dealloc(storage);
                 }
@@ -332,15 +321,19 @@ namespace hpx::detail {
                 if (is_direct())
                 {
                     // direct -> indirect
-                    uninitialized_move_and_destroy(data<direction::direct>(),
-                        storage->data(), size<direction::direct>());
+                    ::hpx::experimental::util::
+                        uninitialized_relocate_n_primitive(
+                            data<direction::direct>(),
+                            size<direction::direct>(), storage->data());
                     storage->size(size<direction::direct>());
                 }
                 else
                 {
                     // indirect -> indirect
-                    uninitialized_move_and_destroy(data<direction::indirect>(),
-                        storage->data(), size<direction::indirect>());
+                    ::hpx::experimental::util::
+                        uninitialized_relocate_n_primitive(
+                            data<direction::indirect>(),
+                            size<direction::indirect>(), storage->data());
                     storage->size(size<direction::indirect>());
                     detail::storage<T>::dealloc(indirect());
                 }
@@ -501,9 +494,12 @@ namespace hpx::detail {
             auto* const erase_end =
                 (std::min)(const_cast<T*>(to), container_end);
 
-            std::move(erase_end, container_end, erase_begin);
+            // forward relocation
+            ::hpx::experimental::util::uninitialized_relocate_primitive(
+                erase_end, container_end, erase_begin);
+
             auto const num_erased = std::distance(erase_begin, erase_end);
-            std::destroy(container_end - num_erased, container_end);
+
             set_size<D>(size<D>() - num_erased);
             return erase_begin;
         }
@@ -547,9 +543,8 @@ namespace hpx::detail {
                 auto s = other.size<direction::direct>();
                 auto* other_end = other_ptr + s;
 
-                std::uninitialized_move(
+                ::hpx::experimental::util::uninitialized_relocate_primitive(
                     other_ptr, other_end, data<direction::direct>());
-                std::destroy(other_ptr, other_end);
                 set_size(s);
             }
             other.set_direct_and_size(0);
@@ -563,24 +558,37 @@ namespace hpx::detail {
         // * source_begin <= target_begin
         // * source_end onwards is uninitialized memory
         //
-        // Destroys then empty elements in [source_begin, source_end)
+        // Destroys the empty elements in [source_begin, source_end)
         auto shift_right(
             T* source_begin, T* source_end, T* target_begin) noexcept
         {
             // 1. uninitialized moves
             auto const num_moves = std::distance(source_begin, source_end);
             auto const target_end = target_begin + num_moves;
-            auto const num_uninitialized_move =
-                (std::min)(num_moves, std::distance(source_end, target_end));
-            std::uninitialized_move(source_end - num_uninitialized_move,
-                source_end, target_end - num_uninitialized_move);
-            std::move_backward(source_begin,
-                source_end - num_uninitialized_move,
-                target_end - num_uninitialized_move);
-            std::destroy(source_begin, (std::min)(source_end, target_begin));
+
+            // Here we split the move into an uninitialized move and a move.
+            // Changing this to a relocation is not certain to be faster.
+            if constexpr (hpx::experimental::is_trivially_relocatable_v<T>)
+            {
+                ::hpx::experimental::util::uninitialized_relocate_backward_primitive(
+                    source_begin, source_end, target_end);
+            }
+            else
+            {
+                auto const num_uninitialized_move = (std::min)(
+                    num_moves, std::distance(source_end, target_end));
+
+                std::uninitialized_move(source_end - num_uninitialized_move,
+                    source_end, target_end - num_uninitialized_move);
+                std::move_backward(source_begin,
+                    source_end - num_uninitialized_move,
+                    target_end - num_uninitialized_move);
+                std::destroy(
+                    source_begin, (std::min)(source_end, target_begin));
+            }
         }
 
-        // makes space for uninitialized data of cout elements. Also updates
+        // makes space for uninitialized data of count elements. Also updates
         // size.
         template <direction D>
         [[nodiscard]] auto make_uninitialized_space_new(
@@ -592,14 +600,25 @@ namespace hpx::detail {
             target.reserve(s + count);
 
             // move everything [begin, pos[
-            auto* target_pos = std::uninitialized_move(
-                data<D>(), p, target.template data<direction::indirect>());
+            auto* target_pos =
+                std::get<1>(::hpx::experimental::util::uninitialized_relocate_primitive(
+                    data<D>(), p, target.template data<direction::indirect>()));
 
             // move everything [pos, end]
-            std::uninitialized_move(p, data<D>() + s, target_pos + count);
+            ::hpx::experimental::util::uninitialized_relocate_primitive(
+                p, data<D>() + s, target_pos + count);
 
             target.template set_size<direction::indirect>(s + count);
-            *this = HPX_MOVE(target);
+
+            // objects are already destroyed from the relocation
+            if (!is_direct())
+            {
+                detail::storage<T>::dealloc(indirect());
+            }
+            set_direct_and_size(0);
+
+            do_move_assign(HPX_MOVE(target));
+
             return target_pos;
         }
 


### PR DESCRIPTION
This PR refactors the existent `small_vector` implementation to use `uninitialized_relocate` in place of move+destroy where possible.